### PR TITLE
Http limit read size

### DIFF
--- a/http.c
+++ b/http.c
@@ -873,7 +873,8 @@ evhttp_handle_chunked_read(struct evhttp_request *req, struct evbuffer *buf)
 		req->ntoread -= len;
 		if (req->ntoread == 0)
 			req->ntoread = -1;
-		if (req->chunk_cb != NULL) {
+		if (req->chunk_cb != NULL &&
+		    (!(req->flags & EVHTTP_REQFLAG_BUFFER_CHUNK) || req->ntoread == -1)) {
 			req->flags |= EVHTTP_REQ_DEFER_FREE;
 			(*req->chunk_cb)(req, req->cb_arg);
 			evbuffer_drain(req->input_buffer,
@@ -3463,6 +3464,13 @@ evhttp_request_new(void (*cb)(struct evhttp_request *, void *), void *arg)
 	if (req != NULL)
 		evhttp_request_free(req);
 	return (NULL);
+}
+
+void
+evhttp_request_set_flags(struct evhttp_request *req, unsigned flags)
+{
+	if (flags & EVHTTP_REQFLAG_BUFFER_CHUNK)
+		req->flags |= EVHTTP_REQFLAG_BUFFER_CHUNK;
 }
 
 void

--- a/include/event2/http.h
+++ b/include/event2/http.h
@@ -415,6 +415,21 @@ struct evhttp_request *evhttp_request_new(
 void evhttp_request_set_chunked_cb(struct evhttp_request *,
     void (*cb)(struct evhttp_request *, void *));
 
+/**
+ * Set flags on the request.  See EVHTTP_REQFLAG_* for more information.
+ * @param flags Zero or more EVHTTP_REQFLAG_* flags to set for this request.
+ */
+void evhttp_request_set_flags(struct evhttp_request *, unsigned flags);
+
+/** Only deliver callbacks for complete HTTP chunks.
+ *
+ * This causes the http library to buffer HTTP content until a complete HTTP
+ * chunk has been received.  It is unsafe to set this flag on a publically
+ * accessible webserver if the max_body_size option is not set, because a client
+ * could send an arbitrarily large HTTP chunk, running the server out of memory.
+ */
+#define EVHTTP_REQFLAG_BUFFER_CHUNK 0x20
+
 /** Frees the request object and removes associated events. */
 void evhttp_request_free(struct evhttp_request *req);
 

--- a/include/event2/http_struct.h
+++ b/include/event2/http_struct.h
@@ -77,6 +77,8 @@ struct {
 #define EVHTTP_REQ_DEFER_FREE		0x0008
 /** The request should be freed upstack */
 #define EVHTTP_REQ_NEEDS_FREE		0x0010
+// From http.h:
+//#define EVHTTP_REQFLAG_BUFFER_CHUNK	0x0020
 
 	struct evkeyvalq *input_headers;
 	struct evkeyvalq *output_headers;


### PR DESCRIPTION
Here is my old patch plus an additional change that adds a flag for the old behavior.

I personally don't think that adding the flag is worth it... but here is the patch if you want it.
