### PR TITLE
Fix: Time race using pthread condition timedwait

### DIFF
--- a/include/event2/util.h
+++ b/include/event2/util.h
@@ -395,6 +395,27 @@ const char *evutil_socket_error_to_string(int errcode);
 #define evutil_socket_error_to_string(errcode) (strerror(errcode))
 #endif
 
+/**
+ * @name Macros for converting between timeval and timespec
+ *
+ * Taken from libc time.h for the fallback. Having the timeradd defined
+ * implies that those macros are available from libc.
+ */
+#ifdef EVENT__HAVE_TIMERADD
+#define evutil_timeval_to_timespec(tv, ts) TIMEVAL_TO_TIMESPEC(tv, ts)
+#define evutil_timespec_to_timeval(tv, ts) TIMESPEC_TO_TIMEVAL(tv, ts)
+#else /* EVENT__HAVE_TIMERADD */
+#define evutil_timeval_to_timespec(tv, ts)     \
+	do {                                       \
+		(ts)->tv_sec = (tv)->tv_sec;           \
+		(ts)->tv_nsec = (tv)->tv_usec * 1000;  \
+	} while (0)
+#define evutil_timespec_to_timeval(tv, ts)     \
+	do {                                       \
+		(tv)->tv_sec = (ts)->tv_sec;           \
+		(tv)->tv_usec = (ts)->tv_nsec / 1000;  \
+	} while (0)
+#endif /* EVENT__HAVE_TIMERADD */
 
 /**
  * @name Manipulation macros for struct timeval.
@@ -465,6 +486,15 @@ ev_int64_t evutil_strtoll(const char *s, char **endptr, int base);
 #else
 struct timezone;
 int evutil_gettimeofday(struct timeval *tv, struct timezone *tz);
+#endif
+
+#ifdef EVENT__HAVE_CLOCK_GETTIME
+#define evutil_clock_gettime(clockid, tp) clock_gettime((clockid), (tp))
+#else
+/* libc defines it to a __S32_TYPE which is a int */
+typedef int clockid_t;
+struct timespec;
+int evutil_clock_gettime(clockid_t clk_id, struct timespec *tp);
 #endif
 
 /** Replacement for snprintf to get consistent behavior on platforms for

--- a/test/regress_thread.c
+++ b/test/regress_thread.c
@@ -393,7 +393,7 @@ thread_conditions_simple(void *arg)
 		}
 		evutil_timeradd(target_delay, &launched_at, &target_time);
 		test_timeval_diff_leq(&target_time, &alerted[i].alerted_at,
-		    0, 50);
+		    0, 150);
 	}
 	tt_int_op(n_broadcast + n_signal + n_timed_out, ==, NUM_THREADS);
 	tt_int_op(n_signal, ==, 1);


### PR DESCRIPTION
The pthread_cond_timedwait() needs an absolute timeout value, generally
taken from the realtime clock of the system (using gettimeofday or
clock_gettime(CLOCK_REALTIME, ...)). However, this clock can go backward
or forward at any time like for instance a NTP adjustment.

The race can occur between the clock time acquisition and the
pthread_cond_timedwait() call which immediately returns with a ETIMEOUT
(normal behavior). By the time the pthread cond call is rescheduled, the
system could have had a NTP adjustment thus making the timeout period
invalid.

This commit forces any pthread condition allocated by libevent and
supporting monotonic clocks to be set with the monotonic clock source
for the timedwait condition.

Also introduce three new macros. A clock_gettime wrapper, a timeval and
timespec conversion that basically use
TIMEVAL_TO_TIMESPEC/TIMESPEC_TO_TIMEVAL from libc if available.

Signed-off-by: David Goulet <dgoulet@ev0ke.net>