### PR TITLE
is that a bug ?

### DIFF
--- a/sample/https-client.c
+++ b/sample/https-client.c
@@ -359,7 +359,7 @@ main(int argc, char **argv)
 	#endif
 
 	if (strcasecmp(scheme, "http") == 0) {
-		bev = bufferevent_socket_new(base, -1, BEV_OPT_CLOSE_ON_FREE);
+		bev = bufferevent_socket_new(base, -1, 0);
 	} else {
 		bev = bufferevent_openssl_socket_new(base, -1, ssl,
 			BUFFEREVENT_SSL_CONNECTING,


### PR DESCRIPTION
I need to reconnect with server when the netword is shutdown and restart, but it does not reconnect as my think.
When I change BEV_OPT_CLOSE_ON_FREE to 0, I found it reconnect ok.
I dont know the details very much, But I doubt there is a bug ,
So I commit this and pull request about it , I wish someone can answer my question.