### PR TITLE
This fixes a bug introduced in 27bd9faf498b91923296cc91643e03ec4055c230

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1112,7 +1112,7 @@ set(EVENT__INCLUDE_DIRS
     "${PROJECT_SOURCE_DIR}/include"
     "${PROJECT_BINARY_DIR}/include")
 set(LIBEVENT_INCLUDE_DIRS ${EVENT__INCLUDE_DIRS} CACHE PATH "Libevent include directories")
-configure_file(${PROJECT_SOURCE_DIR}/cmake/LibeventConfig.cmake.in
+configure_file(${PROJECT_SOURCE_DIR}/cmake/LibeventConfigBuildTree.cmake.in
                 ${PROJECT_BINARY_DIR}/LibeventConfig.cmake
                 @ONLY)
 

--- a/cmake/LibeventConfigBuildTree.cmake.in
+++ b/cmake/LibeventConfigBuildTree.cmake.in
@@ -1,0 +1,17 @@
+# - Config file for the Libevent package
+# It defines the following variables
+#  LIBEVENT_INCLUDE_DIRS - include directories for FooBar
+#  LIBEVENT_LIBRARIES    - libraries to link against
+
+# Get the path of the current file.
+get_filename_component(LIBEVENT_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+
+# Set the include directories.
+set(LIBEVENT_INCLUDE_DIRS "@EVENT__INCLUDE_DIRS@")
+
+# Include the project Targets file, this contains definitions for IMPORTED targets.
+include(${LIBEVENT_CMAKE_DIR}/LibeventTargets.cmake)
+
+# IMPORTED targets from LibeventTargets.cmake
+set(LIBEVENT_LIBRARIES event event_core event_extra)
+


### PR DESCRIPTION
CMake configuration files are intended to be used by other projects to find the library. Specifically the CMake find_package command can use it to find all files related to the project.

The idea is to support 2 different CMake configuration files for Libevent. One if you simply build libevent that is generated for the build tree.
And a second one that is generated for an install target that will be installed on the system and point to where on the system the lib files and such can be find.

So for instance, in the build tree the config would set the cmake variable `LIBEVENT_INCLUDE_DIRS` to `/path/to/libevent/build/include`.
And for the system config it would be set to `/usr/local/include` (or whatever target the user chose when running cmake).

27bd9faf498b91923296cc91643e03ec4055c230 changed this behavior so that both configs would point to the system wide path `/usr/local/include`

This meant that projects just wanting to import directly for the build tree would fail.