### PR TITLE
Add support for appveyor.com windows CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,6 @@
+build_script:
+  - md build
+  - cd build
+  - cmake ..
+  - cmake --build .
+  - ctest --output-on-failure


### PR DESCRIPTION
This does the same thing as Travis-CI but for windows.

@nmathewson
Go to: https://ci.appveyor.com/login -> Login using Github
Click **+New Project** -> Choose **Github** to the left -> Find **Libevent** in the list and click **Add**