### PR TITLE
expose bufferevent_incref/decref

### DIFF
--- a/buffer.c
+++ b/buffer.c
@@ -521,7 +521,7 @@ evbuffer_invoke_callbacks_(struct evbuffer *buffer)
 		if (event_deferred_cb_schedule_(buffer->cb_queue, &buffer->deferred)) {
 			evbuffer_incref_and_lock_(buffer);
 			if (buffer->parent)
-				bufferevent_incref_(buffer->parent);
+				bufferevent_incref(buffer->parent);
 		}
 		EVBUFFER_UNLOCK(buffer);
 	}
@@ -542,7 +542,7 @@ evbuffer_deferred_callback(struct event_callback *cb, void *arg)
 	evbuffer_run_callbacks(buffer, 1);
 	evbuffer_decref_and_unlock_(buffer);
 	if (parent)
-		bufferevent_decref_(parent);
+		bufferevent_decref(parent);
 }
 
 static void

--- a/bufferevent-internal.h
+++ b/bufferevent-internal.h
@@ -327,14 +327,9 @@ int bufferevent_disable_hard_(struct bufferevent *bufev, short event);
 /** Internal: Set up locking on a bufferevent.  If lock is set, use it.
  * Otherwise, use a new lock. */
 int bufferevent_enable_locking_(struct bufferevent *bufev, void *lock);
-/** Internal: Increment the reference count on bufev. */
-void bufferevent_incref_(struct bufferevent *bufev);
 /** Internal: Lock bufev and increase its reference count.
  * unlocking it otherwise. */
 void bufferevent_incref_and_lock_(struct bufferevent *bufev);
-/** Internal: Decrement the reference count on bufev.  Returns 1 if it freed
- * the bufferevent.*/
-int bufferevent_decref_(struct bufferevent *bufev);
 /** Internal: Drop the reference count on bufev, freeing as necessary, and
  * unlocking it otherwise.  Returns 1 if it freed the bufferevent. */
 int bufferevent_decref_and_unlock_(struct bufferevent *bufev);

--- a/bufferevent.c
+++ b/bufferevent.c
@@ -214,7 +214,7 @@ bufferevent_run_deferred_callbacks_unlocked(struct event_callback *cb, void *arg
 		if (event_deferred_cb_schedule_(			\
 			    (bevp)->bev.ev_base,			\
 			&(bevp)->deferred))				\
-			bufferevent_incref_(&(bevp)->bev);		\
+			bufferevent_incref(&(bevp)->bev);		\
 	} while (0)
 
 
@@ -773,11 +773,11 @@ bufferevent_finalize_cb_(struct event_callback *evcb, void *arg_)
 	 * It would probably save us some headaches.
 	 */
 	if (underlying)
-		bufferevent_decref_(underlying);
+		bufferevent_decref(underlying);
 }
 
 int
-bufferevent_decref_(struct bufferevent *bufev)
+bufferevent_decref(struct bufferevent *bufev)
 {
 	BEV_LOCK(bufev);
 	return bufferevent_decref_and_unlock_(bufev);
@@ -793,7 +793,7 @@ bufferevent_free(struct bufferevent *bufev)
 }
 
 void
-bufferevent_incref_(struct bufferevent *bufev)
+bufferevent_incref(struct bufferevent *bufev)
 {
 	struct bufferevent_private *bufev_private =
 	    EVUTIL_UPCAST(bufev, struct bufferevent_private, bev);

--- a/bufferevent_async.c
+++ b/bufferevent_async.c
@@ -212,10 +212,10 @@ bev_async_consider_writing(struct bufferevent_async *beva)
 	}
 
 	/*  XXXX doesn't respect low-water mark very well. */
-	bufferevent_incref_(bev);
+	bufferevent_incref(bev);
 	if (evbuffer_launch_write_(bev->output, at_most,
 	    &beva->write_overlapped)) {
-		bufferevent_decref_(bev);
+		bufferevent_decref(bev);
 		beva->ok = 0;
 		bufferevent_run_eventcb_(bev, BEV_EVENT_ERROR, 0);
 	} else {
@@ -267,11 +267,11 @@ bev_async_consider_reading(struct bufferevent_async *beva)
 		return;
 	}
 
-	bufferevent_incref_(bev);
+	bufferevent_incref(bev);
 	if (evbuffer_launch_read_(bev->input, at_most, &beva->read_overlapped)) {
 		beva->ok = 0;
 		bufferevent_run_eventcb_(bev, BEV_EVENT_ERROR, 0);
-		bufferevent_decref_(bev);
+		bufferevent_decref(bev);
 	} else {
 		beva->read_in_progress = at_most;
 		bufferevent_decrement_read_buckets_(&beva->bev, at_most);
@@ -633,14 +633,14 @@ bufferevent_async_connect_(struct bufferevent *bev, evutil_socket_t fd,
 		return -1;
 
 	event_base_add_virtual_(bev->ev_base);
-	bufferevent_incref_(bev);
+	bufferevent_incref(bev);
 	rc = ext->ConnectEx(fd, sa, socklen, NULL, 0, NULL,
 			    &bev_async->connect_overlapped.overlapped);
 	if (rc || WSAGetLastError() == ERROR_IO_PENDING)
 		return 0;
 
 	event_base_del_virtual_(bev->ev_base);
-	bufferevent_decref_(bev);
+	bufferevent_decref(bev);
 
 	return -1;
 }

--- a/bufferevent_filter.c
+++ b/bufferevent_filter.c
@@ -207,7 +207,7 @@ bufferevent_filter_new(struct bufferevent *underlying,
 	   bufferevent_filtered_outbuf_cb, bufev_f);
 
 	bufferevent_init_generic_timeout_cbs_(downcast(bufev_f));
-	bufferevent_incref_(underlying);
+	bufferevent_incref(underlying);
 
 	bufferevent_enable(underlying, EV_READ|EV_WRITE);
 	bufferevent_suspend_read_(underlying, BEV_SUSPEND_FILT_READ);

--- a/bufferevent_openssl.c
+++ b/bufferevent_openssl.c
@@ -1349,7 +1349,7 @@ bufferevent_openssl_new_impl(struct event_base *base,
 
 	if (underlying) {
 		bufferevent_init_generic_timeout_cbs_(&bev_ssl->bev.bev);
-		bufferevent_incref_(underlying);
+		bufferevent_incref(underlying);
 	}
 
 	bev_ssl->state = state;

--- a/bufferevent_sock.c
+++ b/bufferevent_sock.c
@@ -492,7 +492,7 @@ bufferevent_socket_connect_hostname(struct bufferevent *bev,
 	bufferevent_suspend_write_(bev, BEV_SUSPEND_LOOKUP);
 	bufferevent_suspend_read_(bev, BEV_SUSPEND_LOOKUP);
 
-	bufferevent_incref_(bev);
+	bufferevent_incref(bev);
 	err = evutil_getaddrinfo_async_(evdns_base, hostname, portbuf,
 	    &hint, bufferevent_connect_getaddrinfo_cb, bev);
 
@@ -501,7 +501,7 @@ bufferevent_socket_connect_hostname(struct bufferevent *bev,
 	} else {
 		bufferevent_unsuspend_write_(bev, BEV_SUSPEND_LOOKUP);
 		bufferevent_unsuspend_read_(bev, BEV_SUSPEND_LOOKUP);
-		bufferevent_decref_(bev);
+		bufferevent_decref(bev);
 		return -1;
 	}
 }

--- a/include/event2/bufferevent.h
+++ b/include/event2/bufferevent.h
@@ -563,6 +563,17 @@ EVENT2_EXPORT_SYMBOL
 void bufferevent_unlock(struct bufferevent *bufev);
 
 /**
+   Increment the reference count on bufev.
+*/
+void bufferevent_incref(struct bufferevent *bufev);
+
+/**
+   Decrement the reference count on bufev.  Returns 1 if it freed
+   the bufferevent.
+*/
+int bufferevent_decref(struct bufferevent *bufev);
+
+/**
    Flags that can be passed into filters to let them know how to
    deal with the incoming data.
 */


### PR DESCRIPTION
https://github.com/libevent/libevent/issues/202

I wasn't sure about `bufferevent_incref_and_lock_` and `bufferevent_decref_and_unlock_`, but I don't personally need them, so I left them internal.