### PR TITLE
Fix potential fd leak in listener_read_cb()

### DIFF
--- a/listener.c
+++ b/listener.c
@@ -421,6 +421,8 @@ listener_read_cb(evutil_socket_t fd, short what, void *p)
 		if (lev->refcnt == 1) {
 			int freed = listener_decref_and_unlock(lev);
 			EVUTIL_ASSERT(freed);
+
+			evutil_closesocket(new_fd);
 			return;
 		}
 		--lev->refcnt;


### PR DESCRIPTION
As pointed out by harlan_ in #libevent after running a coverity sweep.
If the listener is free'd, 'new_fd' is never closed.