### PR TITLE
Update strlcpy.c

### DIFF
--- a/strlcpy.c
+++ b/strlcpy.c
@@ -45,10 +45,7 @@ static char *rcsid = "$OpenBSD: strlcpy.c,v 1.5 2001/05/13 15:40:16 deraadt Exp 
  * Returns strlen(src); if retval >= siz, truncation occurred.
  */
 size_t
-event_strlcpy_(dst, src, siz)
-	char *dst;
-	const char *src;
-	size_t siz;
+event_strlcpy_(char *dst, const char *src, size_t siz)
 {
 	register char *d = dst;
 	register const char *s = src;


### PR DESCRIPTION
It's one significant error. Will no one found it?

event_strlcpy_(dst, src, siz)
char *dst;
const char *src;
size_t siz;
{
event_strlcpy_(char *dst, const char *src, size_t siz)
{