### PR TITLE
Check if event already in heap in min_heap_push

### DIFF
--- a/minheap-internal.h
+++ b/minheap-internal.h
@@ -70,7 +70,7 @@ struct event* min_heap_top_(min_heap_t* s) { return s->n ? *s->p : 0; }
 
 int min_heap_push_(min_heap_t* s, struct event* e)
 {
-	if (min_heap_reserve_(s, s->n + 1))
+	if (e->ev_timeout_pos.min_heap_idx != -1 || min_heap_reserve_(s, s->n + 1))
 		return -1;
 	min_heap_shift_up_(s, s->n++, e);
 	return 0;


### PR DESCRIPTION
* I know its not possible that we push event which is already in the 
  heap but its good to have guard rail to protect against such cases.
* Encountered issue in 2.0.19-stable where there were duplicate events
  in the heap in case of http retry therefore on removal we end up with 
  event in heap which never comes out and goes in infinite loop.

Thoughts?