### PR TITLE
Correct URL for the libevent logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://strcpy.net/libevent3.png" alt="libevent logo"/>
+  <img src="http://strcpy.net/libevent3.png" alt="libevent logo"/>
 </p>
 
 


### PR DESCRIPTION
The HTTPS URL for the image is not currently working.